### PR TITLE
Correct sign in product of Gaussian derivation

### DIFF
--- a/03-Gaussians.ipynb
+++ b/03-Gaussians.ipynb
@@ -1976,7 +1976,7 @@
     "$$\\begin{aligned}\n",
     "p(x \\mid z) &\\propto \\exp \\Big[-\\frac{(z-x)^2}{2\\sigma_z^2}\\Big]\\exp \\Big[-\\frac{(x-\\bar\\mu)^2}{2\\bar\\sigma^2}\\Big]\\\\\n",
     "&\\propto \\exp \\Big[-\\frac{(z-x)^2}{2\\sigma_z^2}-\\frac{(x-\\bar\\mu)^2}{2\\bar\\sigma^2}\\Big] \\\\\n",
-    "&\\propto \\exp \\Big[-\\frac{1}{2\\sigma_z^2\\bar\\sigma^2}[\\bar\\sigma^2(z-x)^2-\\sigma_z^2(x-\\bar\\mu)^2]\\Big]\n",
+    "&\\propto \\exp \\Big[-\\frac{1}{2\\sigma_z^2\\bar\\sigma^2}[\\bar\\sigma^2(z-x)^2+\\sigma_z^2(x-\\bar\\mu)^2]\\Big]\n",
     "\\end{aligned}$$\n",
     "\n",
     "Now we multiply out the squared terms and group in terms of the posterior $x$.\n",


### PR DESCRIPTION
"&\\propto \\exp \\Big[-\\frac{1}{2\\sigma_z^2\\bar\\sigma^2}[\\bar\\sigma^2(z-x)^2-\\sigma_z^2(x-\\bar\\mu)^2]\\Big]\n",
changed to
"&\\propto \\exp \\Big[-\\frac{1}{2\\sigma_z^2\\bar\\sigma^2}[\\bar\\sigma^2(z-x)^2+\\sigma_z^2(x-\\bar\\mu)^2]\\Big]\n",